### PR TITLE
Support for variable pen raising/lowering speed and other fixes

### DIFF
--- a/EggDuino.ino
+++ b/EggDuino.ino
@@ -32,45 +32,45 @@
 //#define BOARD_CNCSHIELD
 
 #ifdef BOARD_ZAGGO
-  //Zaggo SphereBot design: http://pleasantsoftware.com/developer/3d/spherebot/
-  //Rotational Stepper:
-  #define step1 11
-  #define dir1 10
-  #define enableRotMotor 9
-  #define rotMicrostep 16  //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
-  //Pen Stepper:
-  #define step2 8
-  #define dir2 7
-  #define enablePenMotor 6
-  #define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
-  //Servo
-  #define servoPin 3
-  #define engraverPin 5
-  //Buttons (uncomment to enable)
-  //#define prgButton 2 // PRG button
-  //#define penToggleButton 12 // pen up/down button
-  //#define motorsButton 4 // motors enable button
+	//Zaggo SphereBot design: http://pleasantsoftware.com/developer/3d/spherebot/
+	//Rotational Stepper:
+	#define step1 11
+	#define dir1 10
+	#define enableRotMotor 9
+	#define rotMicrostep 16  //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+	//Pen Stepper:
+	#define step2 8
+	#define dir2 7
+	#define enablePenMotor 6
+	#define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+	//Servo
+	#define servoPin 3
+	#define engraverPin 5
+	//Buttons (uncomment to enable)
+	//#define prgButton 2 // PRG button
+	//#define penToggleButton 12 // pen up/down button
+	//#define motorsButton 4 // motors enable button
 #endif
 
 #ifdef BOARD_CNCSHIELD
-  //CNC Shield: http://blog.protoneer.co.nz/arduino-cnc-shield/
-  //Rotational Stepper: ("X")
-  #define step1 2
-  #define dir1 5
-  #define enableRotMotor 8
-  #define rotMicrostep 16  //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
-  //Pen Stepper:        ("Y")
-  #define step2 3
-  #define dir2 6
-  #define enablePenMotor 8
-  #define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
-  //Servo
-  #define servoPin 12          // "SpnEn"
-  #define engraverPin 13       // "SpnDir"
-  //Buttons
-  #define prgButton A0         // PRG button ("Abort")
-  #define penToggleButton A1   // pen up/down button ("Hold")
-  #define motorsButton A2      // motors enable button ("Resume")
+	//CNC Shield: http://blog.protoneer.co.nz/arduino-cnc-shield/
+	//Rotational Stepper: ("X")
+	#define step1 2
+	#define dir1 5
+	#define enableRotMotor 8
+	#define rotMicrostep 16  //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+	//Pen Stepper:        ("Y")
+	#define step2 3
+	#define dir2 6
+	#define enablePenMotor 8
+	#define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+	//Servo
+	#define servoPin 12          // "SpnEn"
+	#define engraverPin 13       // "SpnDir"
+	//Buttons
+	#define prgButton A0         // PRG button ("Abort")
+	#define penToggleButton A1   // pen up/down button ("Hold")
+	#define motorsButton A2      // motors enable button ("Resume")
 #endif
 
 

--- a/EggDuino.ino
+++ b/EggDuino.ino
@@ -85,6 +85,9 @@
 void setprgButtonState();
 void doTogglePen();
 void toggleMotors();
+void makeComInterface();
+void initHardware();
+void moveOneStep();
 
 //make Objects
 AccelStepper rotMotor(1, step1, dir1);

--- a/EggDuino.ino
+++ b/EggDuino.ino
@@ -20,40 +20,74 @@
  */
 
 #include "AccelStepper.h" // nice lib from http://www.airspayce.com/mikem/arduino/AccelStepper/
-#include <Servo.h>
+#include "VarSpeedServo.h" // variable speed servo lib https://github.com/netlabtoolkit/VarSpeedServo
 #include "SerialCommand.h" //nice lib from Stefan Rado, https://github.com/kroimon/Arduino-SerialCommand
 #include <avr/eeprom.h>
 #include "button.h"
 
-#define initSting "EBBv13_and_above Protocol emulated by Eggduino-Firmware V1.6a"
-//Rotational Stepper:
-#define step1 11
-#define dir1 10
-#define enableRotMotor 9
-#define rotMicrostep 16  //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
-//Pen Stepper:
-#define step2 8
-#define dir2 7
-#define enablePenMotor 6
-#define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
 
-#define servoPin 3 //Servo
+#define initSting "EBBv13_and_above Protocol emulated by Eggduino-Firmware V1.x"
 
-// EXTRAFEATURES - UNCOMMENT TO USE THEM -------------------------------------------------------------------
+#define BOARD_ZAGGO
+//#define BOARD_CNCSHIELD
 
-// #define prgButton 2 // PRG button
-// #define penToggleButton 12 // pen up/down button
-// #define motorsButton 4 // motors enable button
+#ifdef BOARD_ZAGGO
+  //Zaggo SphereBot design: http://pleasantsoftware.com/developer/3d/spherebot/
+  //Rotational Stepper:
+  #define step1 11
+  #define dir1 10
+  #define enableRotMotor 9
+  #define rotMicrostep 16  //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+  //Pen Stepper:
+  #define step2 8
+  #define dir2 7
+  #define enablePenMotor 6
+  #define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+  //Servo
+  #define servoPin 3
+  //Buttons (uncomment to enable)
+  //#define prgButton 2 // PRG button
+  //#define penToggleButton 12 // pen up/down button
+  //#define motorsButton 4 // motors enable button
+#endif
+
+#ifdef BOARD_CNCSHIELD
+  //CNC Shield: http://blog.protoneer.co.nz/arduino-cnc-shield/
+  //Rotational Stepper: ("X")
+  #define step1 2
+  #define dir1 5
+  #define enableRotMotor 8
+  #define rotMicrostep 16  //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+  //Pen Stepper:        ("Y")
+  #define step2 3
+  #define dir2 6
+  #define enablePenMotor 8
+  #define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
+  //Servo
+  #define servoPin 12          // "SpnEn"
+  //Buttons
+  #define prgButton A0         // PRG button ("Abort")
+  #define penToggleButton A1   // pen up/down button ("Hold")
+  #define motorsButton A2      // motors enable button ("Resume")
+#endif
+
 
 //-----------------------------------------------------------------------------------------------------------
 
+
 #define penUpPosEEAddress ((uint16_t *)0)
 #define penDownPosEEAddress ((uint16_t *)2)
+#define penUpRateEEAddress ((uint16_t *)4)
+#define penDownRateEEAddress ((uint16_t *)6)
+
+void setprgButtonState();
+void doTogglePen();
+void toggleMotors();
 
 //make Objects
 AccelStepper rotMotor(1, step1, dir1);
 AccelStepper penMotor(1, step2, dir2);
-Servo penServo;
+VarSpeedServo penServo;
 SerialCommand SCmd;
 //create Buttons
 #ifdef prgButton
@@ -70,8 +104,8 @@ int penMin=0;
 int penMax=0;
 int penUpPos=5;  //can be overwritten from EBB-Command SC
 int penDownPos=20; //can be overwritten from EBB-Command SC
-int servoRateUp=0; //from EBB-Protocol not implemented on machine-side
-int servoRateDown=0; //from EBB-Protocol not implemented on machine-side
+int servoRateUp=0;
+int servoRateDown=0;
 long rotStepError=0;
 long penStepError=0;
 int penState=penUpPos;

--- a/EggDuino.ino
+++ b/EggDuino.ino
@@ -45,6 +45,7 @@
   #define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
   //Servo
   #define servoPin 3
+  #define engraverPin 5
   //Buttons (uncomment to enable)
   //#define prgButton 2 // PRG button
   //#define penToggleButton 12 // pen up/down button
@@ -65,6 +66,7 @@
   #define penMicrostep 16 //MicrostepMode, only 1,2,4,8,16 allowed, because of Integer-Math in this Sketch
   //Servo
   #define servoPin 12          // "SpnEn"
+  #define engraverPin 13       // "SpnDir"
   //Buttons
   #define prgButton A0         // PRG button ("Abort")
   #define penToggleButton A1   // pen up/down button ("Hold")

--- a/Functions.ino
+++ b/Functions.ino
@@ -147,11 +147,9 @@ void setPen(){
 		sendAck();
 		delay(value);
 	}
-	if (val==NULL && arg !=NULL)  {
+	if (val==NULL && arg !=NULL)
 		sendAck();
-		delay(500);
-	}
-	//	Serial.println("delay");
+
 	if (val==NULL && arg ==NULL)
 		sendError();
 }  

--- a/Functions.ino
+++ b/Functions.ino
@@ -5,9 +5,10 @@ void makeComInterface(){
 	SCmd.addCommand("SC",stepperModeConfigure);
 	SCmd.addCommand("SP",setPen);
 	SCmd.addCommand("SM",stepperMove);
-	SCmd.addCommand("SE",ignore);
+  SCmd.addCommand("SE",setEngraver);
 	SCmd.addCommand("TP",togglePen);
-	SCmd.addCommand("PO",ignore);    //Engraver command, not implemented, gives fake answer
+  SCmd.addCommand("PD",ignore);
+	SCmd.addCommand("PO",pinOutput);
 	SCmd.addCommand("NI",nodeCountIncrement);
 	SCmd.addCommand("ND",nodeCountDecrement);
 	SCmd.addCommand("SN",setNodeCount);
@@ -257,6 +258,40 @@ void stepperModeConfigure(){
 				 sendError();
 		}
 	}
+}
+
+void pinOutput(){
+  char *arg1;
+  char *arg2;
+  char *arg3;
+  int val;
+
+  arg1 = SCmd.next();
+  arg2 = SCmd.next();
+  arg3 = SCmd.next();
+  if (arg1 == NULL || arg2 == NULL || arg3 == NULL) {
+    sendError();
+    return;
+  }
+  //PO,B,3,0 = disable engraver
+  //PO,B,3,1 = enable engraver
+  if (arg1[0] == 'B' && arg2[0] == '3') {
+    val = atoi(arg3);
+    digitalWrite(engraverPin, val);
+  }
+  sendAck();
+}
+
+//currently inkscape extension is using PO command for engraver instead of SE
+void setEngraver(){
+  char *arg;
+  int val;
+  arg = SCmd.next();
+  if (arg != NULL) {
+    val = atoi(arg);
+    digitalWrite(engraverPin, val);
+  }
+  sendAck();
 }
 
 void sendVersion(){

--- a/Functions.ino
+++ b/Functions.ino
@@ -22,9 +22,9 @@ void makeComInterface(){
 void queryPen() {
 	char state;
 	if (penState==penUpPos)
-		state='1';
-	else
 		state='0';
+	else
+		state='1';
 	Serial.print(String(state)+"\r\n");
 	sendAck();
 }
@@ -104,6 +104,19 @@ void stepperMove() {
 	prepareMove(duration, penStepsEBB, rotStepsEBB);
 }
 
+
+void setPenUp() {
+  penServo.write(penUpPos, servoRateUp, true);
+  penState=penUpPos;
+}
+
+
+void setPenDown() {
+  penServo.write(penDownPos, servoRateDown, true);
+  penState=penDownPos;
+}
+
+
 void setPen(){
 	int cmd;
 	int value;
@@ -116,13 +129,11 @@ void setPen(){
 		cmd = atoi(arg);
 		switch (cmd) {
 			case 0:
-				penServo.write(penUpPos);
-				penState=penUpPos;
+				setPenDown();
 				break;
 
 			case 1:
-				penServo.write(penDownPos);
-				penState=penDownPos;
+				setPenUp();
 				break;
 
 			default:
@@ -164,11 +175,9 @@ void togglePen(){
 
 void doTogglePen() {
 	if (penState==penUpPos) {
-		penServo.write(penDownPos);
-		penState=penDownPos;
+		setPenDown();
 	} else   {
-		penServo.write(penUpPos);
-		penState=penUpPos;
+		setPenUp();
 	}
 }
 
@@ -224,12 +233,12 @@ void stepperModeConfigure(){
 		value = atoi(val);
 	if ((arg != NULL) && (val != NULL)){
 		switch (cmd) {
-			case 4: penDownPos= (int) ((float) (value-6000)/(float) 133.3); // transformation from EBB to PWM-Servo
-				storePenDownPosInEE();
+			case 4: penUpPos= (int) ((float) (value-6000)/(float) 133.3); // transformation from EBB to PWM-Servo
+				storePenUpPosInEE();
 				sendAck();
 				break;
-			case 5: penUpPos= (int)((float) (value-6000)/(float) 133.3); // transformation from EBB to PWM-Servo
-				storePenUpPosInEE();
+			case 5: penDownPos= (int)((float) (value-6000)/(float) 133.3); // transformation from EBB to PWM-Servo
+				storePenDownPosInEE();
 				sendAck();
 				break;
 			case 6: //rotMin=value;    ignored
@@ -238,12 +247,14 @@ void stepperModeConfigure(){
 			case 7: //rotMax=value;    ignored
 				sendAck();
 				break;
-			case 11: servoRateUp=value;
-				 sendAck();
-				 break;
-			case 12: servoRateDown=value;
-				 sendAck();
-				 break;
+			case 11: servoRateUp=value / 5;
+        eeprom_update_word(penUpRateEEAddress, servoRateUp);
+				sendAck();
+				break;
+			case 12: servoRateDown=value / 5;
+			  eeprom_update_word(penDownRateEEAddress, servoRateDown);     
+				sendAck();
+				break;
 			default:
 				 sendError();
 		}

--- a/Functions.ino
+++ b/Functions.ino
@@ -130,11 +130,13 @@ void setPen(){
 		cmd = atoi(arg);
 		switch (cmd) {
 			case 0:
+        sendAck();
 				setPenDown();
 				break;
 
 			case 1:
-				setPenUp();
+        sendAck();
+				setPenUp();        
 				break;
 
 			default:
@@ -145,14 +147,8 @@ void setPen(){
 	val = SCmd.next();
 	if (val != NULL) {
 		value = atoi(val);
-		sendAck();
 		delay(value);
 	}
-	if (val==NULL && arg !=NULL)
-		sendAck();
-
-	if (val==NULL && arg ==NULL)
-		sendError();
 }  
 
 void togglePen(){

--- a/Functions.ino
+++ b/Functions.ino
@@ -5,9 +5,9 @@ void makeComInterface(){
 	SCmd.addCommand("SC",stepperModeConfigure);
 	SCmd.addCommand("SP",setPen);
 	SCmd.addCommand("SM",stepperMove);
-  SCmd.addCommand("SE",setEngraver);
+	SCmd.addCommand("SE",setEngraver);
 	SCmd.addCommand("TP",togglePen);
-  SCmd.addCommand("PD",ignore);
+	SCmd.addCommand("PD",ignore);
 	SCmd.addCommand("PO",pinOutput);
 	SCmd.addCommand("NI",nodeCountIncrement);
 	SCmd.addCommand("ND",nodeCountDecrement);
@@ -107,14 +107,14 @@ void stepperMove() {
 
 
 void setPenUp() {
-  penServo.write(penUpPos, servoRateUp, true);
-  penState=penUpPos;
+	penServo.write(penUpPos, servoRateUp, true);
+	penState=penUpPos;
 }
 
 
 void setPenDown() {
-  penServo.write(penDownPos, servoRateDown, true);
-  penState=penDownPos;
+	penServo.write(penDownPos, servoRateDown, true);
+	penState=penDownPos;
 }
 
 
@@ -261,37 +261,37 @@ void stepperModeConfigure(){
 }
 
 void pinOutput(){
-  char *arg1;
-  char *arg2;
-  char *arg3;
-  int val;
+	char *arg1;
+	char *arg2;
+	char *arg3;
+	int val;
 
-  arg1 = SCmd.next();
-  arg2 = SCmd.next();
-  arg3 = SCmd.next();
-  if (arg1 == NULL || arg2 == NULL || arg3 == NULL) {
-    sendError();
-    return;
-  }
-  //PO,B,3,0 = disable engraver
-  //PO,B,3,1 = enable engraver
-  if (arg1[0] == 'B' && arg2[0] == '3') {
-    val = atoi(arg3);
-    digitalWrite(engraverPin, val);
-  }
-  sendAck();
+	arg1 = SCmd.next();
+	arg2 = SCmd.next();
+	arg3 = SCmd.next();
+	if (arg1 == NULL || arg2 == NULL || arg3 == NULL) {
+		sendError();
+		return;
+	}
+	//PO,B,3,0 = disable engraver
+	//PO,B,3,1 = enable engraver
+	if (arg1[0] == 'B' && arg2[0] == '3') {
+		val = atoi(arg3);
+		digitalWrite(engraverPin, val);
+	}
+	sendAck();
 }
 
 //currently inkscape extension is using PO command for engraver instead of SE
 void setEngraver(){
-  char *arg;
-  int val;
-  arg = SCmd.next();
-  if (arg != NULL) {
-    val = atoi(arg);
-    digitalWrite(engraverPin, val);
-  }
-  sendAck();
+	char *arg;
+	int val;
+	arg = SCmd.next();
+	if (arg != NULL) {
+		val = atoi(arg);
+		digitalWrite(engraverPin, val);
+	}
+	sendAck();
 }
 
 void sendVersion(){

--- a/Helper_Functions.ino
+++ b/Helper_Functions.ino
@@ -8,7 +8,7 @@ void initHardware(){
 
 	pinMode(enableRotMotor, OUTPUT);
 	pinMode(enablePenMotor, OUTPUT);
-  pinMode(engraverPin, OUTPUT);
+	pinMode(engraverPin, OUTPUT);
 
 	rotMotor.setMaxSpeed(2000.0);
 	rotMotor.setAcceleration(10000.0);
@@ -22,8 +22,8 @@ void initHardware(){
 void loadPenPosFromEE() {
 	penUpPos = eeprom_read_word(penUpPosEEAddress);
 	penDownPos = eeprom_read_word(penDownPosEEAddress);
-  servoRateUp = eeprom_read_word(penUpRateEEAddress);
-  servoRateDown = eeprom_read_word(penDownRateEEAddress);
+	servoRateUp = eeprom_read_word(penUpRateEEAddress);
+	servoRateDown = eeprom_read_word(penDownRateEEAddress);
 	penState = penUpPos;
 }
 

--- a/Helper_Functions.ino
+++ b/Helper_Functions.ino
@@ -18,7 +18,7 @@ void initHardware(){
 	penServo.write(penState);
 }
 
-void inline loadPenPosFromEE() {
+void loadPenPosFromEE() {
 	penUpPos = eeprom_read_word(penUpPosEEAddress);
 	penDownPos = eeprom_read_word(penDownPosEEAddress);
   servoRateUp = eeprom_read_word(penUpRateEEAddress);
@@ -26,19 +26,19 @@ void inline loadPenPosFromEE() {
 	penState = penUpPos;
 }
 
-void inline storePenUpPosInEE() {
+void storePenUpPosInEE() {
 	eeprom_update_word(penUpPosEEAddress, penUpPos);
 }
 
-void inline storePenDownPosInEE() {
+void storePenDownPosInEE() {
 	eeprom_update_word(penDownPosEEAddress, penDownPos);
 }
 
-void inline sendAck(){
+void sendAck(){
 	Serial.print("OK\r\n");
 }
 
-void inline sendError(){
+void sendError(){
 	Serial.print("unknown CMD\r\n");
 }
 

--- a/Helper_Functions.ino
+++ b/Helper_Functions.ino
@@ -8,6 +8,7 @@ void initHardware(){
 
 	pinMode(enableRotMotor, OUTPUT);
 	pinMode(enablePenMotor, OUTPUT);
+  pinMode(engraverPin, OUTPUT);
 
 	rotMotor.setMaxSpeed(2000.0);
 	rotMotor.setAcceleration(10000.0);
@@ -39,7 +40,7 @@ void sendAck(){
 }
 
 void sendError(){
-	Serial.print("unknown CMD\r\n");
+	Serial.print("!8 Err: Unknown command\r\n");
 }
 
 void motorsOff() {

--- a/Helper_Functions.ino
+++ b/Helper_Functions.ino
@@ -1,3 +1,5 @@
+
+
 void initHardware(){
 	// enable eeprom wait in avr/eeprom.h functions
 	SPMCSR &= ~SELFPRGEN;
@@ -19,6 +21,8 @@ void initHardware(){
 void inline loadPenPosFromEE() {
 	penUpPos = eeprom_read_word(penUpPosEEAddress);
 	penDownPos = eeprom_read_word(penDownPosEEAddress);
+  servoRateUp = eeprom_read_word(penUpRateEEAddress);
+  servoRateDown = eeprom_read_word(penDownRateEEAddress);
 	penState = penUpPos;
 }
 

--- a/README.md
+++ b/README.md
@@ -34,22 +34,24 @@ http://wiki.evilmadscientist.com/Installing_software
 - Eggduino cannot be detected by default by the Eggbot-extension
 	Hopefully, the guys will fix this later on. But we can fix it on our own.
 	Go to your Inkscape-Installation folder and navigate to subfolder .\App\Inkscape\share\extensions
-	
+		
     For version 2.5.0:
 		- open file "eggbot.py" in text editor and search for the line:
 			"Try any devices which seem to have EBB boards attached"
         - comment that block with "#" like this:
-                # Try any devices which seem to have EBB boards attached
-				# for strComPort in eggbot_scan.findEiBotBoards():
-				#	serialPort = self.testSerialPort( strComPort )
-				#	if serialPort:
-				#		self.svgSerialPort = strComPort
-				#		return serialPort
+			```
+			# Try any devices which seem to have EBB boards attached
+			# for strComPort in eggbot_scan.findEiBotBoards():
+			#	serialPort = self.testSerialPort( strComPort )
+			#	if serialPort:
+			#		self.svgSerialPort = strComPort
+			#		return serialPort
+			```
 		- In my version lines 1355-1360
 		
 	For version 2.7.1:
 		- open file "ebb_serial.py" in text editor and search for the following block:
-			
+			```
 			EBBport = None
 			for port in comPortsList:
 				if port[1].startswith("EiBotBoard"):
@@ -60,12 +62,14 @@ http://wiki.evilmadscientist.com/Installing_software
 					if port[2].startswith("USB VID:PID=04D8:FD92"):
 						EBBport = port[0] #Success; EBB found by VID/PID match.
 						break	#stop searching-- we are done.		
-						
+			```			
 		- replace "04D8:FD92" with the VID/PID of your Arduino device.	
 		
 		- alternatively, you can replace "EBBport = None" with your specific port number:
+			```
 			EBBport = "COMxx"				#Windows
 			EBBport = "/dev/tty[something]"	#Linux/Mac	
+			```
 
 		
  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This is the fork of cocktailyogi/EggDuino firmware with added support for servo lowering/raising speed and pin assignment for Protoneer CNC Shield.
+
+
 Eggduino
 ====
 
@@ -15,7 +18,7 @@ Features:
 - Implemented Eggbot-Protocol-Version 2.1.0
 - Turn-on homing: switch-on position of pen will be taken as reference point.
 - No collision-detection!!
-- Supported Servos: At least one type ;-) I use Arduino Servo-Lib with TG9e- standard servo.
+- Supported Servos: standard analog mini servos like TG9e, SG90, ES08MA, HXT900, etc.
 - Full Arduino-Compatible. I used an Arduino Uno
 - Button-support (3 buttons)
 
@@ -28,19 +31,41 @@ Installation:
 - Install Inkscape Tools wit Eggbot extension. Detailed instructions: (You yust need to complete Steps 1 and 2)
 http://wiki.evilmadscientist.com/Installing_software
 
-- Because of an bug in the Eggbot-extension (Function findEiBotBoards()), the Eggduino cannot be detected by default.
+- Eggduino cannot be detected by default by the Eggbot-extension
 	Hopefully, the guys will fix this later on. But we can fix it on our own.
-    It is quiete easy:
+	Go to your Inkscape-Installation folder and navigate to subfolder .\App\Inkscape\share\extensions
 	
-        - Go to your Inkscape-Installationfolder and navigate to subfolder .\App\Inkscape\share\extensions
-		- open File "eggbot.py" in texteditor and search for line:
+    For version 2.5.0:
+		- open file "eggbot.py" in text editor and search for the line:
 			"Try any devices which seem to have EBB boards attached"
-                - comment that block with "#" like this:
-                		# Try any devices which seem to have EBB boards attached
+        - comment that block with "#" like this:
+                # Try any devices which seem to have EBB boards attached
 				# for strComPort in eggbot_scan.findEiBotBoards():
 				#	serialPort = self.testSerialPort( strComPort )
 				#	if serialPort:
 				#		self.svgSerialPort = strComPort
 				#		return serialPort
 		- In my version lines 1355-1360
+		
+	For version 2.7.1:
+		- open file "ebb_serial.py" in text editor and search for the following block:
+			
+			EBBport = None
+			for port in comPortsList:
+				if port[1].startswith("EiBotBoard"):
+					EBBport = port[0] 	#Success; EBB found by name match.
+					break	#stop searching-- we are done.
+			if EBBport is None:
+				for port in comPortsList:
+					if port[2].startswith("USB VID:PID=04D8:FD92"):
+						EBBport = port[0] #Success; EBB found by VID/PID match.
+						break	#stop searching-- we are done.		
+						
+		- replace "04D8:FD92" with the VID/PID of your Arduino device.	
+		
+		- alternatively, you can replace "EBBport = None" with your specific port number:
+			EBBport = "COMxx"				#Windows
+			EBBport = "/dev/tty[something]"	#Linux/Mac	
+
+		
  

--- a/README.md
+++ b/README.md
@@ -32,44 +32,45 @@ Installation:
 http://wiki.evilmadscientist.com/Installing_software
 
 - Eggduino cannot be detected by default by the Eggbot-extension
-	Hopefully, the guys will fix this later on. But we can fix it on our own.
-	Go to your Inkscape-Installation folder and navigate to subfolder .\App\Inkscape\share\extensions
-		
-    For version 2.5.0:
-		- open file "eggbot.py" in text editor and search for the line:
-			"Try any devices which seem to have EBB boards attached"
-        - comment that block with "#" like this:
-			```
-			# Try any devices which seem to have EBB boards attached
-			# for strComPort in eggbot_scan.findEiBotBoards():
-			#	serialPort = self.testSerialPort( strComPort )
-			#	if serialPort:
-			#		self.svgSerialPort = strComPort
-			#		return serialPort
-			```
-		- In my version lines 1355-1360
-		
-	For version 2.7.1:
-		- open file "ebb_serial.py" in text editor and search for the following block:
-			```
-			EBBport = None
-			for port in comPortsList:
-				if port[1].startswith("EiBotBoard"):
-					EBBport = port[0] 	#Success; EBB found by name match.
-					break	#stop searching-- we are done.
-			if EBBport is None:
-				for port in comPortsList:
-					if port[2].startswith("USB VID:PID=04D8:FD92"):
-						EBBport = port[0] #Success; EBB found by VID/PID match.
-						break	#stop searching-- we are done.		
-			```			
-		- replace "04D8:FD92" with the VID/PID of your Arduino device.	
-		
-		- alternatively, you can replace "EBBport = None" with your specific port number:
-			```
-			EBBport = "COMxx"				#Windows
-			EBBport = "/dev/tty[something]"	#Linux/Mac	
-			```
+    Hopefully, the guys will fix this later on. But we can fix it on our own.  
+    Go to your Inkscape-Installation folder and navigate to subfolder .\App\Inkscape\share\extensions
+        
+For version 2.5.0:
 
-		
+    - open file "eggbot.py" in text editor and search for the line:
+        "Try any devices which seem to have EBB boards attached"
+
+    - comment that block with "#" like this:
+        # Try any devices which seem to have EBB boards attached
+        # for strComPort in eggbot_scan.findEiBotBoards():
+        #   serialPort = self.testSerialPort( strComPort )
+        #   if serialPort:
+        #       self.svgSerialPort = strComPort
+        #       return serialPort
+
+    - In my version lines 1355-1360
+    
+For version 2.7.1:
+
+    - open file "ebb_serial.py" in text editor and search for the following block:
+
+        EBBport = None
+        for port in comPortsList:
+            if port[1].startswith("EiBotBoard"):
+                EBBport = port[0]   #Success; EBB found by name match.
+                break   #stop searching-- we are done.
+        if EBBport is None:
+            for port in comPortsList:
+                if port[2].startswith("USB VID:PID=04D8:FD92"):
+                    EBBport = port[0] #Success; EBB found by VID/PID match.
+                    break   #stop searching-- we are done.      
+ 
+    - replace "04D8:FD92" with the VID/PID of your Arduino device.  
+    
+    - alternatively, you can replace "EBBport = None" with your specific port number:
+        EBBport = "COMxx"               #Windows
+        EBBport = "/dev/tty[something]" #Linux/Mac  
+
+
+        
  

--- a/VarSpeedServo.cpp
+++ b/VarSpeedServo.cpp
@@ -1,0 +1,531 @@
+/*
+ Servo.cpp - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+ Copyright (c) 2009 Michael Margolis.  All right reserved.
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*
+  Function slowmove and supporting code added 2010 by Korman. Above limitations apply
+  to all added code, except for the official maintainer of the Servo library. If he,
+  and only he deems the enhancment a good idea to add to the official Servo library,
+  he may add it without the requirement to name the author of the parts original to
+  this version of the library.
+*/
+
+/*
+  Updated 2013 by Philip van Allen (pva), 
+  -- updated for Arduino 1.0 +
+  -- consolidated slowmove into the write command (while keeping slowmove() for compatibility
+     with Korman's version)
+  -- added wait parameter to allow write command to block until move is complete
+  -- added sequence playing ability to asynchronously move the servo through a series of positions, must be called in a loop
+
+  A servo is activated by creating an instance of the Servo class passing the desired pin to the attach() method.
+  The servos are pulsed in the background using the value most recently written using the write() method
+
+  Note that analogWrite of PWM on pins associated with the timer are disabled when the first servo is attached.
+  Timers are seized as needed in groups of 12 servos - 24 servos use two timers, 48 servos will use four.
+  The sequence used to sieze timers is defined in timers.h
+
+  The methods are:
+
+   VarSpeedServo - Class for manipulating servo motors connected to Arduino pins.
+
+   attach(pin )  - Attaches a servo motor to an i/o pin.
+   attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
+   default min is 544, max is 2400  
+ 
+   write(value)     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
+   write(value, speed) - speed varies the speed of the move to new position 0=full speed, 1-255 slower to faster
+   write(value, speed, wait) - wait is a boolean that, if true, causes the function call to block until move is complete
+
+   writeMicroseconds() - Sets the servo pulse width in microseconds 
+   read()      - Gets the last written servo pulse width as an angle between 0 and 180. 
+   readMicroseconds()  - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
+   attached()  - Returns true if there is a servo attached. 
+   detach()    - Stops an attached servos from pulsing its i/o pin. 
+
+   slowmove(value, speed) - The same as write(value, speed), retained for compatibility with Korman's version
+
+   stop() - stops the servo at the current position
+
+   sequencePlay(sequence, sequencePositions); // play a looping sequence starting at position 0
+   sequencePlay(sequence, sequencePositions, loop, startPosition); // play sequence with number of positions, loop if true, start at position
+   sequenceStop(); // stop sequence at current position
+
+ */
+
+#include <avr/interrupt.h>
+#include <Arduino.h> // updated from WProgram.h to Arduino.h for Arduino 1.0+, pva
+
+#include "VarSpeedServo.h"
+
+#define usToTicks(_us)    (( clockCyclesPerMicrosecond()* _us) / 8)     // converts microseconds to tick (assumes prescale of 8)  // 12 Aug 2009
+#define ticksToUs(_ticks) (( (unsigned)_ticks * 8)/ clockCyclesPerMicrosecond() ) // converts from ticks back to microseconds
+
+
+#define TRIM_DURATION       2                               // compensation ticks to trim adjust for digitalWrite delays // 12 August 2009
+
+//#define NBR_TIMERS        (MAX_SERVOS / SERVOS_PER_TIMER)
+
+static servo_t servos[MAX_SERVOS];                          // static array of servo structures
+static volatile int8_t Channel[_Nbr_16timers ];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
+
+uint8_t ServoCount = 0;                                     // the total number of attached servos
+
+// sequence vars
+
+servoSequencePoint initSeq[] = {{0,100},{45,100}};
+
+//sequence_t sequences[MAX_SEQUENCE];
+
+// convenience macros
+#define SERVO_INDEX_TO_TIMER(_servo_nbr) ((timer16_Sequence_t)(_servo_nbr / SERVOS_PER_TIMER)) // returns the timer controlling this servo
+#define SERVO_INDEX_TO_CHANNEL(_servo_nbr) (_servo_nbr % SERVOS_PER_TIMER)       // returns the index of the servo on this timer
+#define SERVO_INDEX(_timer,_channel)  ((_timer*SERVOS_PER_TIMER) + _channel)     // macro to access servo index by timer and channel
+#define SERVO(_timer,_channel)  (servos[SERVO_INDEX(_timer,_channel)])            // macro to access servo class by timer and channel
+
+#define SERVO_MIN() (MIN_PULSE_WIDTH - this->min * 4)  // minimum value in uS for this servo
+#define SERVO_MAX() (MAX_PULSE_WIDTH - this->max * 4)  // maximum value in uS for this servo 
+
+/************ static functions common to all instances ***********************/
+
+static inline void handle_interrupts(timer16_Sequence_t timer, volatile uint16_t *TCNTn, volatile uint16_t* OCRnA)
+{
+  if( Channel[timer] < 0 )
+    *TCNTn = 0; // channel set to -1 indicated that refresh interval completed so reset the timer 
+  else{
+    if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && SERVO(timer,Channel[timer]).Pin.isActive == true )  
+      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,LOW); // pulse this channel low if activated   
+  }
+
+  Channel[timer]++;    // increment to the next channel
+  if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
+
+	// Extension for slowmove
+	if (SERVO(timer,Channel[timer]).speed) {
+		// Increment ticks by speed until we reach the target.
+		// When the target is reached, speed is set to 0 to disable that code.
+		if (SERVO(timer,Channel[timer]).target > SERVO(timer,Channel[timer]).ticks) {
+			SERVO(timer,Channel[timer]).ticks += SERVO(timer,Channel[timer]).speed;
+			if (SERVO(timer,Channel[timer]).target <= SERVO(timer,Channel[timer]).ticks) {
+				SERVO(timer,Channel[timer]).ticks = SERVO(timer,Channel[timer]).target;
+				SERVO(timer,Channel[timer]).speed = 0;
+			}
+		}
+		else {
+			SERVO(timer,Channel[timer]).ticks -= SERVO(timer,Channel[timer]).speed;
+			if (SERVO(timer,Channel[timer]).target >= SERVO(timer,Channel[timer]).ticks) {
+				SERVO(timer,Channel[timer]).ticks = SERVO(timer,Channel[timer]).target;
+				SERVO(timer,Channel[timer]).speed = 0;
+			}
+		}
+	}
+	// End of Extension for slowmove
+
+	// Todo
+	
+    *OCRnA = *TCNTn + SERVO(timer,Channel[timer]).ticks;
+    if(SERVO(timer,Channel[timer]).Pin.isActive == true)     // check if activated
+      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // its an active channel so pulse it high   
+  }  
+  else { 
+    // finished all channels so wait for the refresh period to expire before starting over 
+    if( (unsigned)*TCNTn <  (usToTicks(REFRESH_INTERVAL) + 4) )  // allow a few ticks to ensure the next OCR1A not missed
+      *OCRnA = (unsigned int)usToTicks(REFRESH_INTERVAL);  
+    else 
+      *OCRnA = *TCNTn + 4;  // at least REFRESH_INTERVAL has elapsed
+    Channel[timer] = -1; // this will get incremented at the end of the refresh period to start again at the first channel
+  }
+}
+
+#ifndef WIRING // Wiring pre-defines signal handlers so don't define any if compiling for the Wiring platform
+// Interrupt handlers for Arduino 
+#if defined(_useTimer1)
+SIGNAL (TIMER1_COMPA_vect) 
+{ 
+  handle_interrupts(_timer1, &TCNT1, &OCR1A); 
+}
+#endif
+
+#if defined(_useTimer3)
+SIGNAL (TIMER3_COMPA_vect) 
+{ 
+  handle_interrupts(_timer3, &TCNT3, &OCR3A); 
+}
+#endif
+
+#if defined(_useTimer4)
+SIGNAL (TIMER4_COMPA_vect) 
+{
+  handle_interrupts(_timer4, &TCNT4, &OCR4A); 
+}
+#endif
+
+#if defined(_useTimer5)
+SIGNAL (TIMER5_COMPA_vect) 
+{
+  handle_interrupts(_timer5, &TCNT5, &OCR5A); 
+}
+#endif
+
+#elif defined WIRING
+// Interrupt handlers for Wiring 
+#if defined(_useTimer1)
+void Timer1Service() 
+{ 
+  handle_interrupts(_timer1, &TCNT1, &OCR1A); 
+}
+#endif
+#if defined(_useTimer3)
+void Timer3Service() 
+{ 
+  handle_interrupts(_timer3, &TCNT3, &OCR3A); 
+}
+#endif
+#endif
+
+
+static void initISR(timer16_Sequence_t timer)
+{  
+#if defined (_useTimer1)
+  if(timer == _timer1) {
+    TCCR1A = 0;             // normal counting mode 
+    TCCR1B = _BV(CS11);     // set prescaler of 8 
+    TCNT1 = 0;              // clear the timer count 
+#if defined(__AVR_ATmega8__)|| defined(__AVR_ATmega128__)
+    TIFR |= _BV(OCF1A);      // clear any pending interrupts; 
+    TIMSK |=  _BV(OCIE1A) ;  // enable the output compare interrupt  
+#else
+    // here if not ATmega8 or ATmega128
+    TIFR1 |= _BV(OCF1A);     // clear any pending interrupts; 
+    TIMSK1 |=  _BV(OCIE1A) ; // enable the output compare interrupt 
+#endif    
+#if defined(WIRING)       
+    timerAttach(TIMER1OUTCOMPAREA_INT, Timer1Service); 
+#endif	
+  } 
+#endif  
+
+#if defined (_useTimer3)
+  if(timer == _timer3) {
+    TCCR3A = 0;             // normal counting mode 
+    TCCR3B = _BV(CS31);     // set prescaler of 8  
+    TCNT3 = 0;              // clear the timer count 
+#if defined(__AVR_ATmega128__)
+    TIFR |= _BV(OCF3A);     // clear any pending interrupts;   
+	ETIMSK |= _BV(OCIE3A);  // enable the output compare interrupt     
+#else  
+    TIFR3 = _BV(OCF3A);     // clear any pending interrupts; 
+    TIMSK3 =  _BV(OCIE3A) ; // enable the output compare interrupt      
+#endif
+#if defined(WIRING)    
+    timerAttach(TIMER3OUTCOMPAREA_INT, Timer3Service);  // for Wiring platform only	
+#endif  
+  }
+#endif
+
+#if defined (_useTimer4)
+  if(timer == _timer4) {
+    TCCR4A = 0;             // normal counting mode 
+    TCCR4B = _BV(CS41);     // set prescaler of 8  
+    TCNT4 = 0;              // clear the timer count 
+    TIFR4 = _BV(OCF4A);     // clear any pending interrupts; 
+    TIMSK4 =  _BV(OCIE4A) ; // enable the output compare interrupt
+  }    
+#endif
+
+#if defined (_useTimer5)
+  if(timer == _timer5) {
+    TCCR5A = 0;             // normal counting mode 
+    TCCR5B = _BV(CS51);     // set prescaler of 8  
+    TCNT5 = 0;              // clear the timer count 
+    TIFR5 = _BV(OCF5A);     // clear any pending interrupts; 
+    TIMSK5 =  _BV(OCIE5A) ; // enable the output compare interrupt      
+  }
+#endif
+} 
+
+static void finISR(timer16_Sequence_t timer)
+{
+    //disable use of the given timer
+#if defined WIRING   // Wiring
+  if(timer == _timer1) {
+    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+    TIMSK1 &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt
+    #else 
+    TIMSK &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt   
+    #endif
+    timerDetach(TIMER1OUTCOMPAREA_INT); 
+  }
+  else if(timer == _timer3) {     
+    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+    TIMSK3 &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+    #else
+    ETIMSK &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+    #endif
+    timerDetach(TIMER3OUTCOMPAREA_INT);
+  }
+#else
+    //For arduino - in future: call here to a currently undefined function to reset the timer
+#endif
+}
+
+static boolean isTimerActive(timer16_Sequence_t timer)
+{
+  // returns true if any servo is active on this timer
+  for(uint8_t channel=0; channel < SERVOS_PER_TIMER; channel++) {
+    if(SERVO(timer,channel).Pin.isActive == true)
+      return true;
+  }
+  return false;
+}
+
+
+/****************** end of static functions ******************************/
+
+VarSpeedServo::VarSpeedServo()
+{
+  if( ServoCount < MAX_SERVOS) {
+    this->servoIndex = ServoCount++;                    // assign a servo index to this instance
+	  servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
+    this->curSeqPosition = 0;
+    this->curSequence = initSeq;
+  }
+  else
+    this->servoIndex = INVALID_SERVO ;  // too many servos 
+}
+
+uint8_t VarSpeedServo::attach(int pin)
+{
+  return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
+}
+
+uint8_t VarSpeedServo::attach(int pin, int min, int max)
+{
+  if(this->servoIndex < MAX_SERVOS ) {
+    pinMode( pin, OUTPUT) ;                                   // set servo pin to output
+    servos[this->servoIndex].Pin.nbr = pin;  
+    // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128 
+    this->min  = (MIN_PULSE_WIDTH - min)/4; //resolution of min/max is 4 uS
+    this->max  = (MAX_PULSE_WIDTH - max)/4; 
+    // initialize the timer if it has not already been initialized 
+    timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
+    if(isTimerActive(timer) == false)
+      initISR(timer);    
+    servos[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
+  } 
+  return this->servoIndex ;
+}
+
+void VarSpeedServo::detach()  
+{
+  servos[this->servoIndex].Pin.isActive = false;  
+  timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
+  if(isTimerActive(timer) == false) {
+    finISR(timer);
+  }
+}
+
+void VarSpeedServo::write(int value)
+{  
+  if(value < MIN_PULSE_WIDTH)
+  {  // treat values less than 544 as angles in degrees (valid values in microseconds are handled as microseconds)
+    // updated to use constrain() instead of if(), pva
+    value = constrain(value, 0, 180);
+    value = map(value, 0, 180, SERVO_MIN(),  SERVO_MAX());      
+  }
+  this->writeMicroseconds(value);
+}
+
+void VarSpeedServo::writeMicroseconds(int value)
+{
+  // calculate and store the values for the given channel
+  byte channel = this->servoIndex;
+  if( (channel >= 0) && (channel < MAX_SERVOS) )   // ensure channel is valid
+  {  
+    if( value < SERVO_MIN() )          // ensure pulse width is valid
+      value = SERVO_MIN();
+    else if( value > SERVO_MAX() )
+      value = SERVO_MAX();   
+    
+  	value -= TRIM_DURATION;
+    value = usToTicks(value);  // convert to ticks after compensating for interrupt overhead - 12 Aug 2009
+
+    uint8_t oldSREG = SREG;
+    cli();
+    servos[channel].ticks = value;  
+    SREG = oldSREG;   
+
+	// Extension for slowmove
+	// Disable slowmove logic.
+	servos[channel].speed = 0;  
+	// End of Extension for slowmove
+  } 
+}
+
+// Extension for slowmove
+/*
+  write(value, speed) - Just like write but at reduced speed.
+
+  value - Target position for the servo. Identical use as value of the function write.
+  speed - Speed at which to move the servo.
+          speed=0 - Full speed, identical to write
+          speed=1 - Minimum speed
+          speed=255 - Maximum speed
+*/
+void VarSpeedServo::write(int value, uint8_t speed) {
+	// This fuction is a copy of write and writeMicroseconds but value will be saved
+	// in target instead of in ticks in the servo structure and speed will be save
+	// there too.
+
+  int degrees = value;
+
+	if (speed) {
+		if (value < MIN_PULSE_WIDTH) {
+			// treat values less than 544 as angles in degrees (valid values in microseconds are handled as microseconds)
+      		// updated to use constrain instead of if, pva
+      		value = constrain(value, 0, 180);
+      		value = map(value, 0, 180, SERVO_MIN(),  SERVO_MAX());    
+		}
+		// calculate and store the values for the given channel
+		byte channel = this->servoIndex;
+		if( (channel >= 0) && (channel < MAX_SERVOS) ) {   // ensure channel is valid
+      		// updated to use constrain instead of if, pva
+      		value = constrain(value, SERVO_MIN(), SERVO_MAX());
+
+			value = value - TRIM_DURATION;
+			value = usToTicks(value);  // convert to ticks after compensating for interrupt overhead - 12 Aug 2009
+
+			// Set speed and direction
+			uint8_t oldSREG = SREG;
+			cli();
+			servos[channel].target = value;  
+			servos[channel].speed = speed;  
+			SREG = oldSREG;   
+		}
+	} 
+	else {
+		write (value);
+	}
+}
+
+void VarSpeedServo::write(int value, uint8_t speed, bool wait) {
+  write(value, speed);
+  if (wait) { // block until the servo is at its new position
+    if (value < MIN_PULSE_WIDTH) {
+      while (read() != value) {
+        delay(5);
+      }
+    } else {
+      while (readMicroseconds() != value) {
+        delay(5);
+      }
+    }
+  }
+}
+
+void VarSpeedServo::stop() {
+  write(read());
+}
+
+void VarSpeedServo::slowmove(int value, uint8_t speed) {
+  // legacy function to support original version of VarSpeedServo
+  write(value, speed);
+}
+
+// End of Extension for slowmove
+
+
+int VarSpeedServo::read() // return the value as degrees
+{
+  return  map( this->readMicroseconds()+1, SERVO_MIN(), SERVO_MAX(), 0, 180);     
+}
+
+int VarSpeedServo::readMicroseconds()
+{
+  unsigned int pulsewidth;
+  if( this->servoIndex != INVALID_SERVO )
+    pulsewidth = ticksToUs(servos[this->servoIndex].ticks)  + TRIM_DURATION ;   // 12 aug 2009
+  else 
+    pulsewidth  = 0;
+
+  return pulsewidth;   
+}
+
+bool VarSpeedServo::attached()
+{
+  return servos[this->servoIndex].Pin.isActive ;
+}
+
+uint8_t VarSpeedServo::sequencePlay(servoSequencePoint sequenceIn[], uint8_t numPositions, bool loop, uint8_t startPos) {
+  uint8_t oldSeqPosition = this->curSeqPosition;
+
+  if( this->curSequence != sequenceIn) {
+    //Serial.println("newSeq");
+    this->curSequence = sequenceIn;
+    this->curSeqPosition = startPos;
+    oldSeqPosition = 255;
+  }
+  
+  if (read() == sequenceIn[this->curSeqPosition].position && this->curSeqPosition != CURRENT_SEQUENCE_STOP) {
+    this->curSeqPosition++;
+    
+    if (this->curSeqPosition >= numPositions) { // at the end of the loop
+      if (loop) { // reset to the beginning of the loop
+        this->curSeqPosition = 0;
+      } else { // stop the loop
+        this->curSeqPosition = CURRENT_SEQUENCE_STOP;
+      }
+    }
+  }
+
+  if (this->curSeqPosition != oldSeqPosition && this->curSeqPosition != CURRENT_SEQUENCE_STOP) { 
+    // CURRENT_SEQUENCE_STOP position means the animation has ended, and should no longer be played
+    // otherwise move to the next position
+    write(sequenceIn[this->curSeqPosition].position, sequenceIn[this->curSeqPosition].speed);
+    //Serial.println(this->seqCurPosition);
+  }
+  
+  return this->curSeqPosition;
+}
+
+uint8_t VarSpeedServo::sequencePlay(servoSequencePoint sequenceIn[], uint8_t numPositions) {
+  return sequencePlay(sequenceIn, numPositions, true, 0);
+}
+
+void VarSpeedServo::sequenceStop() {
+  write(read());
+  this->curSeqPosition = CURRENT_SEQUENCE_STOP;
+}
+
+/*
+	To do
+int VarSpeedServo::targetPosition() {
+	byte channel = this->servoIndex;
+	return map( servos[channel].target+1, SERVO_MIN(), SERVO_MAX(), 0, 180);
+}
+
+int VarSpeedServo::targetPositionMicroseconds() {
+	byte channel = this->servoIndex;
+	return servos[channel].target;
+}
+
+bool VarSpeedServo::isMoving() {
+	byte channel = this->servoIndex;
+	int servos[channel].target;
+}
+*/

--- a/VarSpeedServo.h
+++ b/VarSpeedServo.h
@@ -1,0 +1,180 @@
+/*
+  VarSpeedServo.h - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+  Copyright (c) 2009 Michael Margolis.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+
+/*
+  Function slowmove and supporting code added 2010 by Korman. Above limitations apply
+  to all added code, except for the official maintainer of the Servo library. If he,
+  and only he deems the enhancment a good idea to add to the official Servo library,
+  he may add it without the requirement to name the author of the parts original to
+  this version of the library.
+*/
+
+/*
+  Updated 2013 by Philip van Allen (pva), 
+  -- updated for Arduino 1.0 +
+  -- consolidated slowmove into the write command (while keeping slowmove() for compatibility
+     with Korman's version)
+  -- added wait parameter to allow write command to block until move is complete
+  -- added sequence playing ability to asynchronously move the servo through a series of positions, must be called in a loop
+
+  
+  A servo is activated by creating an instance of the Servo class passing the desired pin to the attach() method.
+  The servos are pulsed in the background using the value most recently written using the write() method
+
+  Note that analogWrite of PWM on pins associated with the timer are disabled when the first servo is attached.
+  Timers are seized as needed in groups of 12 servos - 24 servos use two timers, 48 servos will use four.
+  The sequence used to sieze timers is defined in timers.h
+
+  The methods are:
+
+   VarSpeedServo - Class for manipulating servo motors connected to Arduino pins.
+
+   attach(pin )  - Attaches a servo motor to an i/o pin.
+   attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
+   default min is 544, max is 2400  
+ 
+   write(value)     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
+   write(value, speed) - speed varies the speed of the move to new position 0=full speed, 1-255 slower to faster
+   write(value, speed, wait) - wait is a boolean that, if true, causes the function call to block until move is complete
+
+   writeMicroseconds() - Sets the servo pulse width in microseconds 
+   read()      - Gets the last written servo pulse width as an angle between 0 and 180. 
+   readMicroseconds()  - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
+   attached()  - Returns true if there is a servo attached. 
+   detach()    - Stops an attached servos from pulsing its i/o pin. 
+
+   slowmove(value, speed) - The same as write(value, speed), retained for compatibility with Korman's version
+
+   stop() - stops the servo at the current position
+
+   sequencePlay(sequence, sequencePositions); // play a looping sequence starting at position 0
+   sequencePlay(sequence, sequencePositions, loop, startPosition); // play sequence with number of positions, loop if true, start at position
+   sequenceStop(); // stop sequence at current position
+
+ */
+
+#ifndef VarSpeedServo_h
+#define VarSpeedServo_h
+
+#include <inttypes.h>
+
+/* 
+ * Defines for 16 bit timers used with  Servo library 
+ *
+ * If _useTimerX is defined then TimerX is a 16 bit timer on the curent board
+ * timer16_Sequence_t enumerates the sequence that the timers should be allocated
+ * _Nbr_16timers indicates how many 16 bit timers are available.
+ *
+ */
+
+// Say which 16 bit timers can be used and in what order
+#if defined(__AVR_ATmega1280__)  || defined(__AVR_ATmega2560__)
+#define _useTimer5
+#define _useTimer1 
+#define _useTimer3
+#define _useTimer4 
+typedef enum { _timer5, _timer1, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
+
+#elif defined(__AVR_ATmega32U4__)  
+#define _useTimer3
+#define _useTimer1 
+typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t ;
+
+#elif defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__)
+#define _useTimer3
+#define _useTimer1
+typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t ;
+
+#elif defined(__AVR_ATmega128__) ||defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+#define _useTimer3
+#define _useTimer1
+typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t ;
+
+#else  // everything else
+#define _useTimer1
+typedef enum { _timer1, _Nbr_16timers } timer16_Sequence_t ;                  
+#endif
+
+#define VarSpeedServo_VERSION           2      // software version of this library
+
+#define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo  
+#define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo 
+#define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
+#define REFRESH_INTERVAL    20000     // minumim time to refresh servos in microseconds 
+
+#define SERVOS_PER_TIMER       12     // the maximum number of servos controlled by one timer 
+#define MAX_SERVOS   (_Nbr_16timers  * SERVOS_PER_TIMER)
+
+#define INVALID_SERVO         255     // flag indicating an invalid servo index
+
+#define CURRENT_SEQUENCE_STOP   255    // used to indicate the current sequence is not used and sequence should stop
+
+
+typedef struct  {
+  uint8_t nbr        :6 ;             // a pin number from 0 to 63
+  uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false 
+} ServoPin_t   ;  
+
+typedef struct {
+  ServoPin_t Pin;
+  unsigned int ticks;
+	unsigned int target;			// Extension for slowmove
+	uint8_t speed;					// Extension for slowmove
+} servo_t;
+
+typedef struct {
+  uint8_t position;
+  uint8_t speed;
+} servoSequencePoint;
+
+class VarSpeedServo
+{
+public:
+  VarSpeedServo();
+  uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
+  uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
+  void detach();
+  void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds
+  void write(int value, uint8_t speed); // Move to given position at reduced speed.
+          // speed=0 is identical to write, speed=1 slowest and speed=255 fastest.
+          // On the RC-Servos tested, speeds differences above 127 can't be noticed,
+          // because of the mechanical limits of the servo.
+  void write(int value, uint8_t speed, bool wait); // wait parameter causes call to block until move completes
+  void writeMicroseconds(int value); // Write pulse width in microseconds 
+  void slowmove(int value, uint8_t speed);
+  void stop(); // stop the servo where it is
+  
+  int read();                        // returns current pulse width as an angle between 0 and 180 degrees
+  int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
+  bool attached();                   // return true if this servo is attached, otherwise false 
+
+  uint8_t sequencePlay(servoSequencePoint sequenceIn[], uint8_t numPositions, bool loop, uint8_t startPos);
+  uint8_t sequencePlay(servoSequencePoint sequenceIn[], uint8_t numPositions); // play a looping sequence starting at position 0
+  void sequenceStop(); // stop movement
+private:
+   uint8_t servoIndex;               // index into the channel data for this servo
+   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
+   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH
+   servoSequencePoint * curSequence; // for sequences
+   uint8_t curSeqPosition; // for sequences
+
+};
+
+#endif


### PR DESCRIPTION
- After building my EggBot with EggDuino firmware, I noticed that quick servo moves destroy the tips of markers, making the lines very think. To fix this, I've added the support for configurable servo rate using VarSpeedServo library. 
- According to EBB protocol specs (http://www.schmalzhaus.com/EBB/EBBCommands.html), command "SP,1" moves pen up and "SP,0" moves pen down. In EggDuino up/down was reversed everywhere. This commit fixes this. 
- Included pin definitions for Protoneer CNC Shield which is available very cheap on eBay
- Added instructions for patching the new version of EggBot extension
- Engraver support
