### PR TITLE
Fixed #16 (compilation error)

### DIFF
--- a/Helper_Functions.ino
+++ b/Helper_Functions.ino
@@ -16,25 +16,25 @@ void initHardware(){
 	penServo.write(penState);
 }
 
-void inline loadPenPosFromEE() {
+inline void loadPenPosFromEE() {
 	penUpPos = eeprom_read_word(penUpPosEEAddress);
 	penDownPos = eeprom_read_word(penDownPosEEAddress);
 	penState = penUpPos;
 }
 
-void inline storePenUpPosInEE() {
+inline void storePenUpPosInEE() {
 	eeprom_update_word(penUpPosEEAddress, penUpPos);
 }
 
-void inline storePenDownPosInEE() {
+inline void storePenDownPosInEE() {
 	eeprom_update_word(penDownPosEEAddress, penDownPos);
 }
 
-void inline sendAck(){
+inline void sendAck(){
 	Serial.print("OK\r\n");
 }
 
-void inline sendError(){
+inline void sendError(){
 	Serial.print("unknown CMD\r\n");
 }
 


### PR DESCRIPTION
This fixes compilation error in Arduino IDE 1.8.5 on Mac:

```
Functions:29: error: 'sendAck' was not declared in this scope
sendAck();
```